### PR TITLE
Simplificando la función que calcula el costo total de las ordenes

### DIFF
--- a/app/Jobs/CalculateTotalOrdersCost.php
+++ b/app/Jobs/CalculateTotalOrdersCost.php
@@ -18,12 +18,11 @@ class CalculateTotalOrdersCost implements ShouldQueue
     {
         $totalCost = Order::with('orderLines.product')
             ->get()
-            ->flatMap(function ($order) {
-                return $order->orderLines->map(function ($orderLine) {
+            ->sum(function ($order) {
+                return $order->orderLines->sum(function ($orderLine) {
                     return $orderLine->qty * $orderLine->product->cost;
                 });
-            })
-            ->sum();
+            });
 
         echo "El costo total de todas las órdenes es: $totalCost";
     }


### PR DESCRIPTION
[Fix] Modificación de función que calcula el costo total de las ordenes, más simple evitando el uso de flatMap o map